### PR TITLE
EditorImport時の不具合への暫定対処

### DIFF
--- a/Assets/VRM10/Runtime/FastSpringBone/FastSpringBoneService.cs
+++ b/Assets/VRM10/Runtime/FastSpringBone/FastSpringBoneService.cs
@@ -48,6 +48,10 @@ namespace UniVRM10.FastSpringBones
         {
             get
             {
+                // v0.127.1_hotfix_2
+                // EditorImport時にDontDestroyOnLoadが呼ばれるとエラーになるので、それを防ぐ暫定対処
+                if (!Application.isPlaying) return null;
+                
                 if (_instance) return _instance;
 
 #if UNITY_2022_3_OR_NEWER


### PR DESCRIPTION
VrmのEditorImport時にDontDestroyOnLoadが呼び出されてしまい、Importプロセスが失敗する不具合への暫定対処を行うPRです。
本家でも同様の不具合に対する修正があがっているので、いずれは解消されそうですがPOPOPO側を無事動作させるためひとまずFix。
https://github.com/vrm-c/UniVRM/pull/2473