### PR TITLE
GlbLowLevelParserの入力をReadOnlyMemoryでとれるようにする

### DIFF
--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/Anglelimit/Anglelimit.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/Anglelimit/Anglelimit.cs
@@ -18,7 +18,7 @@ namespace UniGLTF.SpringBoneJobs
                 case AnglelimitTypes.Cone:
                     {
                         var angleSpaceToWorld = anglelimitSpaceToWorld(logic, joint, parentRotation);
-                        var tailDir = math.mul(math.inverse(angleSpaceToWorld), math.normalize(nextTail - head));
+                        var tailDir = math.mul(math.inverse(angleSpaceToWorld), math.normalizesafe(nextTail - head));
                         tailDir = AnglelimitCone.Apply(tailDir, joint.anglelimit1);
                         return head + math.mul(angleSpaceToWorld, tailDir) * logic.length;
                     }
@@ -26,7 +26,7 @@ namespace UniGLTF.SpringBoneJobs
                 case AnglelimitTypes.Hinge:
                     {
                         var angleSpaceToWorld = anglelimitSpaceToWorld(logic, joint, parentRotation);
-                        var tailDir = math.mul(math.inverse(angleSpaceToWorld), math.normalize(nextTail - head));
+                        var tailDir = math.mul(math.inverse(angleSpaceToWorld), math.normalizesafe(nextTail - head));
                         tailDir = AnglelimitHinge.Apply(tailDir, joint.anglelimit1);
                         return head + math.mul(angleSpaceToWorld, tailDir) * logic.length;
                     }
@@ -35,7 +35,7 @@ namespace UniGLTF.SpringBoneJobs
                 case AnglelimitTypes.Spherical:
                     {
                         var angleSpaceToWorld = anglelimitSpaceToWorld(logic, joint, parentRotation);
-                        var tailDir = math.mul(math.inverse(angleSpaceToWorld), math.normalize(nextTail - head));
+                        var tailDir = math.mul(math.inverse(angleSpaceToWorld), math.normalizesafe(nextTail - head));
                         tailDir = AnglelimitSpherical.Apply(tailDir, joint.anglelimit1, joint.anglelimit2);
                         return head + math.mul(angleSpaceToWorld, tailDir) * logic.length;
                     }
@@ -66,8 +66,8 @@ namespace UniGLTF.SpringBoneJobs
         // https://discussions.unity.com/t/unity-mathematics-equivalent-to-quaternion-fromtorotation/237459
         public static quaternion fromToQuaternion(in float3 from, in float3 to)
         {
-            var fromNorm = math.normalize(from);
-            var toNorm = math.normalize(to);
+            var fromNorm = math.normalizesafe(from);
+            var toNorm = math.normalizesafe(to);
             var dot = math.dot(fromNorm, toNorm);
 
             // Handle the case where from and to are parallel but opposite
@@ -77,13 +77,13 @@ namespace UniGLTF.SpringBoneJobs
                 var perpAxis = math.abs(fromNorm.x) > math.abs(fromNorm.z)
                     ? new float3(-fromNorm.y, fromNorm.x, 0f)
                     : new float3(0f, -fromNorm.z, fromNorm.y);
-                return quaternion.AxisAngle(math.normalize(perpAxis), math.PI);
+                return quaternion.AxisAngle(math.normalizesafe(perpAxis), math.PI);
             }
 
             // General case
             return quaternion.AxisAngle(
                   angle: math.acos(math.clamp(dot, -1f, 1f)),
-                  axis: math.normalize(math.cross(fromNorm, toNorm))
+                  axis: math.normalizesafe(math.cross(fromNorm, toNorm))
                 );
         }
 

--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/Anglelimit/AnglelimitHinge.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/Anglelimit/AnglelimitHinge.cs
@@ -12,7 +12,7 @@ namespace UniGLTF.SpringBoneJobs
             // x要素を0にし、正規化する
             float3 tailDir = src;
             tailDir.x = 0.0f;
-            tailDir = math.normalize(tailDir);
+            tailDir = math.normalizesafe(tailDir);
 
             // tailDirのy要素をjointに設定されたangleの余弦と比較する
             var cosAngle = math.cos(limitAngle);

--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/Blittables/BlittableTransform.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/Blittables/BlittableTransform.cs
@@ -140,7 +140,7 @@ namespace UniGLTF.SpringBoneJobs.Blittables
 
             if(parent.HasValue)
             {
-                newLocalRotation = math.normalize(math.mul(math.inverse(parent.Value.rotation), newRotation));
+                newLocalRotation = math.normalizesafe(math.mul(math.inverse(parent.Value.rotation), newRotation));
                 newLocalToWorldMatrix = math.mul(parent.Value.localToWorldMatrix, float4x4.TRS(localPosition, newLocalRotation, localScale));
             }
             else

--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/InputPorts/FastSpringBoneBuffer.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/InputPorts/FastSpringBoneBuffer.cs
@@ -125,7 +125,7 @@ namespace UniGLTF.SpringBoneJobs.InputPorts
                     parentTransformIndex: Array.IndexOf<Transform>(Transforms, joint.Transform.parent),
                     tailTransformIndex: Array.IndexOf<Transform>(Transforms, tailJoint.Transform),
                     localRotation: joint.DefaultLocalRotation,
-                    boneAxis: math.normalize(localChildPosition),
+                    boneAxis: math.normalizesafe(localChildPosition),
                     length: math.length(localChildPosition));
             }
         }

--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/SpringBoneCollision.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/SpringBoneCollision.cs
@@ -47,10 +47,10 @@ namespace UniGLTF.SpringBoneJobs
             if (math.lengthsq(nextTail - worldPosition) <= (r * r))
             {
                 // ヒット。Colliderの半径方向に押し出す
-                var normal = math.normalize(nextTail - worldPosition);
+                var normal = math.normalizesafe(nextTail - worldPosition);
                 var posFromCollider = worldPosition + normal * r;
                 // 長さをboneLengthに強制
-                newNextTail = headTransform.position + math.normalize(posFromCollider - headTransform.position) * logic.length;
+                newNextTail = headTransform.position + math.normalizesafe(posFromCollider - headTransform.position) * logic.length;
                 return true;
             }
             else
@@ -76,7 +76,7 @@ namespace UniGLTF.SpringBoneJobs
                 // head側半球の球判定
                 return TryResolveSphereCollision(joint, collider, worldPosition, headTransform, maxColliderScale, logic, nextTail, out newNextTail);
             }
-            var P = math.normalize(direction);
+            var P = math.normalizesafe(direction);
             var Q = headTransform.position - worldPosition;
             var dot = math.dot(P, Q);
             if (dot <= 0)
@@ -110,7 +110,7 @@ namespace UniGLTF.SpringBoneJobs
             in float3 nextTail, out float3 newNextTail)
         {
             var transformedOffset = MathHelper.MultiplyPoint(colliderTransform.localToWorldMatrix, collider.offset);
-            var transformedNormal = math.normalize(MathHelper.MultiplyVector(colliderTransform.localToWorldMatrix, collider.tailOrNormal));
+            var transformedNormal = math.normalizesafe(MathHelper.MultiplyVector(colliderTransform.localToWorldMatrix, collider.tailOrNormal));
             var delta = nextTail - transformedOffset;
 
             // ジョイントとコライダーの距離。負の値は衝突していることを示す
@@ -145,7 +145,7 @@ namespace UniGLTF.SpringBoneJobs
             // ジョイントとコライダーの距離の方向。衝突している場合、この方向にジョイントを押し出す
             if (distance < 0)
             {
-                var direction = -1 * math.normalize(delta);
+                var direction = -1 * math.normalizesafe(delta);
                 newNextTail = nextTail - direction * distance;
                 return true;
             }
@@ -192,7 +192,7 @@ namespace UniGLTF.SpringBoneJobs
             // ジョイントとコライダーの距離の方向。衝突している場合、この方向にジョイントを押し出す
             if (distance < 0)
             {
-                var direction = -1 * math.normalize(delta);
+                var direction = -1 * math.normalizesafe(delta);
                 newNextTail = nextTail - direction * distance;
                 return true;
             }

--- a/Assets/UniGLTF/Runtime/SpringBoneJobs/UpdateFastSpringBoneJob.cs
+++ b/Assets/UniGLTF/Runtime/SpringBoneJobs/UpdateFastSpringBoneJob.cs
@@ -92,7 +92,7 @@ namespace UniGLTF.SpringBoneJobs
                                + external * scalingFactor; // 外力による移動量
 
                 // 長さをboneLengthに強制
-                nextTail = headTransform.position + math.normalize(nextTail - headTransform.position) * logic.length;
+                nextTail = headTransform.position + math.normalizesafe(nextTail - headTransform.position) * logic.length;
 
                 nextTail = Anglelimit.Apply(logic, joint, parentRotation, head: headTransform.position, nextTail: nextTail);
 

--- a/Assets/UniGLTF/Runtime/UniGLTF.asmdef
+++ b/Assets/UniGLTF/Runtime/UniGLTF.asmdef
@@ -8,7 +8,7 @@
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
-    "allowUnsafeCode": false,
+    "allowUnsafeCode": true,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,

--- a/Assets/UniGLTF/Runtime/UniGLTF/Format/ExtensionsAndExtras/gltfExtension.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/Format/ExtensionsAndExtras/gltfExtension.cs
@@ -130,8 +130,7 @@ namespace UniGLTF
 
         public override string ToString()
         {
-            var bytes = m_json.Value.Bytes;
-            return "import: " + Encoding.UTF8.GetString(bytes.Array, bytes.Offset, bytes.Count);
+            return "import: " + Encoding.UTF8.GetString(m_json.Value.Bytes.Span);
         }
 
         public IEnumerable<KeyValuePair<JsonNode, JsonNode>> ObjectItems()
@@ -147,7 +146,7 @@ namespace UniGLTF
 
         public override void Serialize(JsonFormatter f)
         {
-            f.Raw(m_json.Value.Bytes);
+            f.Raw(m_json.Value.Bytes.Span);
         }
     }
 

--- a/Assets/UniGLTF/Runtime/UniGLTF/Format/glbTypes.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/Format/glbTypes.cs
@@ -28,10 +28,11 @@ namespace UniGLTF
 
     public struct GlbChunk
     {
-        public GlbChunkType ChunkType => ChunkTypeString.ToChunkType();
+        public GlbChunkType ChunkType => ChunkTypeBytes.ToChunkType();
 
-        public string ChunkTypeString;
-        public ArraySegment<Byte> Bytes;
+        public string ChunkTypeString => Encoding.ASCII.GetString(ChunkTypeBytes.Span);
+        public ReadOnlyMemory<byte> Bytes;
+        public ReadOnlyMemory<byte> ChunkTypeBytes;
 
         public GlbChunk(string json) : this(
             GlbChunkType.JSON.ToChunkTypeString(),
@@ -49,7 +50,13 @@ namespace UniGLTF
 
         public GlbChunk(string chunkTypeString, ArraySegment<Byte> bytes)
         {
-            ChunkTypeString = chunkTypeString;
+            ChunkTypeBytes = Encoding.ASCII.GetBytes(chunkTypeString);
+            Bytes = bytes;
+        }
+
+        public GlbChunk(ReadOnlyMemory<byte> chunkTypeBytes, ReadOnlyMemory<byte> bytes)
+        {
+            ChunkTypeBytes = chunkTypeBytes;
             Bytes = bytes;
         }
 
@@ -60,12 +67,12 @@ namespace UniGLTF
 
         public static GlbChunk CreateJson(ArraySegment<byte> bytes)
         {
-            return new GlbChunk(GlbChunkType.JSON.ToChunkTypeString(), bytes);
+            return new GlbChunk(glbImporter.GLB_JSON_BYTES, bytes);
         }
 
         public static GlbChunk CreateBin(ArraySegment<Byte> bytes)
         {
-            return new GlbChunk(GlbChunkType.BIN.ToChunkTypeString(), bytes);
+            return new GlbChunk(glbImporter.GLB_BIN_BYTES, bytes);
         }
 
         byte GetPaddingByte()
@@ -87,11 +94,11 @@ namespace UniGLTF
         public int WriteTo(Stream s)
         {
             // padding
-            var paddingValue = Bytes.Count % 4;
+            var paddingValue = Bytes.Length % 4;
             var padding = (paddingValue > 0) ? 4 - paddingValue : 0;
 
             // size
-            var bytes = BitConverter.GetBytes((int)(Bytes.Count + padding));
+            var bytes = BitConverter.GetBytes((int)(Bytes.Length + padding));
             s.Write(bytes, 0, bytes.Length);
 
             // chunk type
@@ -116,7 +123,7 @@ namespace UniGLTF
             }
 
             // body
-            s.Write(Bytes.Array, Bytes.Offset, Bytes.Count);
+            s.Write(Bytes.Span);
 
             // 4byte align
             var pad = GetPaddingByte();
@@ -125,7 +132,7 @@ namespace UniGLTF
                 s.WriteByte(pad);
             }
 
-            return 4 + 4 + Bytes.Count + padding;
+            return 4 + 4 + Bytes.Length + padding;
         }
     }
 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfData.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfData.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using Unity.Collections;
 
 namespace UniGLTF
@@ -32,7 +33,7 @@ namespace UniGLTF
         /// JSON chunk ToString
         /// > This chunk MUST be the very first chunk of Binary glTF asset
         /// </summary>
-        public string Json { get; }
+        public string Json => _json ?? Encoding.UTF8.GetString(_jsonBytes.Span);
 
         /// <summary>
         /// GLTF parsed from JSON chunk
@@ -72,10 +73,13 @@ namespace UniGLTF
         /// <returns></returns>
         Dictionary<string, NativeArray<byte>> _UriCache = new Dictionary<string, NativeArray<byte>>();
 
-        public GltfData(string targetPath, string json, glTF gltf, IReadOnlyList<GlbChunk> chunks, IStorage storage, MigrationFlags migrationFlags)
+        private string _json;
+        readonly ReadOnlyMemory<byte> _jsonBytes;
+
+        public GltfData(string targetPath, ReadOnlyMemory<byte> jsonBytes, glTF gltf, IReadOnlyList<GlbChunk> chunks, IStorage storage, MigrationFlags migrationFlags)
         {
             TargetPath = targetPath;
-            Json = json;
+            _jsonBytes = jsonBytes;
             GLTF = gltf;
             Chunks = chunks;
             _storage = storage;
@@ -106,7 +110,7 @@ namespace UniGLTF
         {
             return new GltfData(
                 string.Empty,
-                string.Empty,
+                Array.Empty<byte>(),
                 gltf,
                 new List<GlbChunk>
                 {

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/NativeArrayManager.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/NativeArrayManager.cs
@@ -93,7 +93,7 @@ namespace UniGLTF
             unsafe
             {
                 var handle = data.Pin();
-                var nativeArray = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<T>(handle.Pointer, data.Length, Allocator.Persistent);
+                var nativeArray = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<T>(handle.Pointer, data.Length, Allocator.None);
                 m_disposables.Add(nativeArray);
                 m_disposables.Add(handle);
 #if ENABLE_UNITY_COLLECTIONS_CHECKS

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/NativeArrayManager.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/NativeArrayManager.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Collections.Generic;
 using Unity.Collections;
 using System.Runtime.InteropServices;
+using Unity.Collections.LowLevel.Unsafe;
 
 namespace UniGLTF
 {
@@ -89,11 +90,17 @@ namespace UniGLTF
 
         public NativeArray<T> CreateNativeArray<T>(ReadOnlyMemory<T> data) where T : struct
         {
-            var array = CreateNativeArray<T>(data.Length);
-            var toSpan = array.AsSpan();
-            var fromSpan = data.Span;
-            fromSpan.CopyTo(toSpan);
-            return array;
+            unsafe
+            {
+                var handle = data.Pin();
+                var nativeArray = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<T>(handle.Pointer, data.Length, Allocator.Persistent);
+                m_disposables.Add(nativeArray);
+                m_disposables.Add(handle);
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+                NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref nativeArray, AtomicSafetyHandle.Create());
+#endif
+              return nativeArray;
+            }
         }
 
         /// <summary>

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/NativeArrayManager.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/NativeArrayManager.cs
@@ -87,6 +87,15 @@ namespace UniGLTF
             return array;
         }
 
+        public NativeArray<T> CreateNativeArray<T>(ReadOnlyMemory<T> data) where T : struct
+        {
+            var array = CreateNativeArray<T>(data.Length);
+            var toSpan = array.AsSpan();
+            var fromSpan = data.Span;
+            fromSpan.CopyTo(toSpan);
+            return array;
+        }
+
         /// <summary>
         /// サイズの違う型にコピーする。
         /// 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/Parser/GlbLowLevelParser.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/Parser/GlbLowLevelParser.cs
@@ -35,7 +35,7 @@ namespace UniGLTF
                 var jsonBytes = chunks[0].Bytes;
                 return ParseGltf(
                     path,
-                    Encoding.UTF8.GetString(jsonBytes.Span),
+                    jsonBytes,
                     chunks,
                     default,
                     new MigrationFlags()
@@ -74,6 +74,11 @@ namespace UniGLTF
         }
 
         public static GltfData ParseGltf(string path, string json, IReadOnlyList<GlbChunk> chunks, IStorage storage, MigrationFlags migrationFlags)
+        {
+            return ParseGltf(path, Encoding.UTF8.GetBytes(json), chunks, storage, migrationFlags); 
+        }
+
+        public static GltfData ParseGltf(string path, ReadOnlyMemory<byte> json, IReadOnlyList<GlbChunk> chunks, IStorage storage, MigrationFlags migrationFlags)
         {
             var jsonNode = json.ParseAsJson();
             var GLTF = GltfDeserializer.Deserialize(jsonNode);

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/Parser/GlbLowLevelParser.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/Parser/GlbLowLevelParser.cs
@@ -75,14 +75,15 @@ namespace UniGLTF
 
         public static GltfData ParseGltf(string path, string json, IReadOnlyList<GlbChunk> chunks, IStorage storage, MigrationFlags migrationFlags)
         {
-            var GLTF = GltfDeserializer.Deserialize(json.ParseAsJson());
+            var jsonNode = json.ParseAsJson();
+            var GLTF = GltfDeserializer.Deserialize(jsonNode);
             if (GLTF.asset.version != "2.0")
             {
                 throw new UniGLTFException("unknown gltf version {0}", GLTF.asset.version);
             }
 
             // Version Compatibility
-            RestoreOlderVersionValues(json, GLTF);
+            RestoreOlderVersionValues(jsonNode, GLTF);
 
             FixMeshNameUnique(GLTF);
             FixBlendShapeNameUnique(GLTF);
@@ -300,16 +301,15 @@ namespace UniGLTF
             }
         }
 
-        private static void RestoreOlderVersionValues(string Json, glTF GLTF)
+        private static void RestoreOlderVersionValues(JsonNode jsonNode, glTF GLTF)
         {
-            var parsed = UniJSON.JsonParser.Parse(Json);
             for (int i = 0; i < GLTF.images.Count; ++i)
             {
                 if (string.IsNullOrEmpty(GLTF.images[i].name))
                 {
                     try
                     {
-                        var extraName = parsed["images"][i]["extra"]["name"].Value.GetString();
+                        var extraName = jsonNode["images"][i]["extra"]["name"].Value.GetString();
                         if (!string.IsNullOrEmpty(extraName))
                         {
                             GLTF.images[i].name = extraName;

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/Parser/GlbLowLevelParser.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/Parser/GlbLowLevelParser.cs
@@ -25,15 +25,17 @@ namespace UniGLTF
             _binary = specifiedBinary;
         }
 
-        public GltfData Parse()
+        public GltfData Parse() => Parse(_path, _binary);
+
+        public static GltfData Parse(string path, ReadOnlyMemory<byte> binary)
         {
             try
             {
-                var chunks = ParseGlbChunks(_binary);
+                var chunks = ParseGlbChunks(binary);
                 var jsonBytes = chunks[0].Bytes;
                 return ParseGltf(
-                    _path,
-                    Encoding.UTF8.GetString(jsonBytes.Array, jsonBytes.Offset, jsonBytes.Count),
+                    path,
+                    Encoding.UTF8.GetString(jsonBytes.Span),
                     chunks,
                     default,
                     new MigrationFlags()
@@ -49,7 +51,7 @@ namespace UniGLTF
             }
         }
 
-        public static List<GlbChunk> ParseGlbChunks(byte[] data)
+        public static List<GlbChunk> ParseGlbChunks(ReadOnlyMemory<byte> data)
         {
             var chunks = glbImporter.ParseGlbChunks(data);
 

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureIO/Import/DeserializingTextureInfo.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureIO/Import/DeserializingTextureInfo.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using Unity.Collections;
+using UnityEngine;
 
 namespace UniGLTF
 {
@@ -8,9 +9,11 @@ namespace UniGLTF
     public sealed class DeserializingTextureInfo
     {
         /// <summary>
-        /// Texture のバイト列
+        /// Texture のバイト列。
+        /// GltfData が保持する NativeArray をコピーせずそのまま参照するため、Dispose してはならない。
+        /// 未設定の場合は IsCreated == false となる。
         /// </summary>
-        public byte[] ImageData { get; }
+        public NativeArray<byte> ImageData { get; }
 
         /// <summary>
         /// Texture の mimeType
@@ -44,7 +47,7 @@ namespace UniGLTF
 
         public TextureImportTypes ImportTypes { get; }
 
-        public DeserializingTextureInfo(byte[] imageData, string dataMimeType, ColorSpace colorSpace, bool useMipmap, FilterMode filterMode, TextureWrapMode wrapModeU, TextureWrapMode wrapModeV)
+        public DeserializingTextureInfo(NativeArray<byte> imageData, string dataMimeType, ColorSpace colorSpace, bool useMipmap, FilterMode filterMode, TextureWrapMode wrapModeU, TextureWrapMode wrapModeV)
         {
             ImageData = imageData;
             DataMimeType = dataMimeType;
@@ -55,7 +58,7 @@ namespace UniGLTF
             WrapModeV = wrapModeV;
         }
 
-        public DeserializingTextureInfo(byte[] imageData, string dataMimeType, ColorSpace colorSpace, SamplerParam samplerParam, TextureImportTypes importTypes)
+        public DeserializingTextureInfo(NativeArray<byte> imageData, string dataMimeType, ColorSpace colorSpace, SamplerParam samplerParam, TextureImportTypes importTypes)
         {
             ImageData = imageData;
             DataMimeType = dataMimeType;

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureIO/Import/GltfTextureImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureIO/Import/GltfTextureImporter.cs
@@ -23,11 +23,7 @@ namespace UniGLTF
                 TextureImportTypes.sRGB,
                 default,
                 default,
-                () =>
-                {
-                    var imageBytes = data.GetBytesFromImage(imageIndex);
-                    return Task.FromResult<(byte[], string)?>((ToArray(imageBytes?.binary ?? default), imageBytes?.mimeType));
-                },
+                () => Task.FromResult(GetImageBytesFromImageIndex(data, imageIndex)),
                 default, default, default, default, default);
             return (texDesc.SubAssetKey, texDesc);
         }
@@ -214,19 +210,10 @@ namespace UniGLTF
             return (offset, scale);
         }
 
-        private static (byte[] binary, string mimeType)? GetImageBytesFromImageIndex(GltfData data, int imageIndex)
+        private static (NativeArray<byte> binary, string mimeType)? GetImageBytesFromImageIndex(GltfData data, int imageIndex)
         {
-            if (imageIndex >= 0 && imageIndex < data.GLTF.images.Count)
-            {
-                var imageBytes = data.GetBytesFromImage(imageIndex);
-                if (imageBytes.HasValue)
-                {
-
-                    return (ToArray(imageBytes.Value.binary), imageBytes.Value.mimeType);
-                }
-            }
-
-            return default;
+            // NOTE: GltfData が保持する NativeArray をコピーせずそのまま返す。
+            return data.GetBytesFromImage(imageIndex);
         }
 
         private static int? GetImageIndexFromTextureIndex(GltfData data, int textureIndex)
@@ -271,26 +258,6 @@ namespace UniGLTF
                 throw new UniGLTFNotSupportedException("KHR_texture_basisu is only supported with all textures Y-flipped.");
             }
             return true;
-        }
-
-
-        private static byte[] ToArray(NativeArray<byte> bytes)
-        {
-            // if (bytes.Array == null)
-            // {
-            //     return new byte[] { };
-            // }
-            // else if (bytes.Offset == 0 && bytes.Count == bytes.Array.Length)
-            // {
-            //     return bytes.Array;
-            // }
-            // else
-            // {
-            //     var result = new byte[bytes.Count];
-            //     Buffer.BlockCopy(bytes.Array, bytes.Offset, result, 0, result.Length);
-            //     return result;
-            // }
-            return bytes.ToArray();
         }
     }
 }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureIO/Import/KtxTextureDeserializer.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureIO/Import/KtxTextureDeserializer.cs
@@ -15,15 +15,16 @@ namespace UniGLTF
 #pragma warning restore 1998
         {
 #if USE_COM_UNITY_CLOUD_KTX
-            if (textureInfo.ImageData == null) return null;
+            if (!textureInfo.ImageData.IsCreated) return null;
 
             // NOTE: IAwaitCaller を無視するので、同期読み込みを期待する環境で同期読み込みができない
             try
             {
                 var ktxTexture = new KtxTexture();
-                using var nativeBytes = new NativeArray<byte>(textureInfo.ImageData, Allocator.Persistent);
+                // NOTE: GltfData が保持する NativeArray をそのまま渡す。
+                //       KtxUnity は Open() 内で同期的に読み取るだけで所有権を取らないため、コピー不要。
                 var result = await ktxTexture.LoadFromBytes(
-                    nativeBytes,
+                    textureInfo.ImageData,
                     linear: textureInfo.ColorSpace == ColorSpace.Linear,
                     mipChain: textureInfo.UseMipmap
                 );

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureIO/Import/TextureDescriptor.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureIO/Import/TextureDescriptor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Unity.Collections;
 using UnityEngine;
 
 namespace UniGLTF
@@ -11,9 +12,12 @@ namespace UniGLTF
     ///   Texture2D.LoadImage
     /// extact:
     ///   File.WriteAllBytes
+    ///
+    /// NOTE: binary は GltfData が保持する NativeArray をそのまま参照する。
+    ///       コピーを避けるため、呼び出し側で Dispose してはならない。
     /// </summary>
     /// <returns></returns>
-    public delegate Task<(byte[] binary, string mimeType)?> GetTextureBytesAsync();
+    public delegate Task<(NativeArray<byte> binary, string mimeType)?> GetTextureBytesAsync();
 
     /// <summary>
     /// 入力 glTF ファイルを Import した結果生成される、UnityEngine.Texture のアセット 1 つを確定させる Import 情報。

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureIO/Import/TextureFactory.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureIO/Import/TextureFactory.cs
@@ -84,7 +84,7 @@ namespace UniGLTF
                         // https://docs.unity3d.com/2018.4/Documentation/Manual/StandardShaderMaterialParameterNormalMap.html
                         var data0 = await texDesc.Index0();
                         var rawTexture = await TextureDeserializer.LoadTextureAsync(
-                            new DeserializingTextureInfo(data0?.binary, data0?.mimeType, ColorSpace.Linear, texDesc.Sampler, texDesc.TextureType),
+                            new DeserializingTextureInfo(data0?.binary ?? default, data0?.mimeType, ColorSpace.Linear, texDesc.Sampler, texDesc.TextureType),
                             awaitCaller);
                         rawTexture.name = subAssetKey.Name;
                         _textureCache.Add(subAssetKey, rawTexture);
@@ -100,14 +100,14 @@ namespace UniGLTF
                         {
                             var data0 = await texDesc.Index0();
                             metallicRoughnessTexture = await TextureDeserializer.LoadTextureAsync(
-                                new DeserializingTextureInfo(data0?.binary, data0?.mimeType, ColorSpace.Linear, texDesc.Sampler, texDesc.TextureType),
+                                new DeserializingTextureInfo(data0?.binary ?? default, data0?.mimeType, ColorSpace.Linear, texDesc.Sampler, texDesc.TextureType),
                                 awaitCaller);
                         }
                         if (texDesc.Index1 != null)
                         {
                             var data1 = await texDesc.Index1();
                             occlusionTexture = await TextureDeserializer.LoadTextureAsync(
-                                new DeserializingTextureInfo(data1?.binary, data1?.mimeType, ColorSpace.Linear, texDesc.Sampler, texDesc.TextureType),
+                                new DeserializingTextureInfo(data1?.binary ?? default, data1?.mimeType, ColorSpace.Linear, texDesc.Sampler, texDesc.TextureType),
                                 awaitCaller);
                         }
 
@@ -127,7 +127,7 @@ namespace UniGLTF
                     {
                         var data0 = await texDesc.Index0();
                         var rawTexture = await TextureDeserializer.LoadTextureAsync(
-                            new DeserializingTextureInfo(data0?.binary, data0?.mimeType, ColorSpace.sRGB, texDesc.Sampler, texDesc.TextureType),
+                            new DeserializingTextureInfo(data0?.binary ?? default, data0?.mimeType, ColorSpace.sRGB, texDesc.Sampler, texDesc.TextureType),
                             awaitCaller);
                         rawTexture.name = subAssetKey.Name;
                         _textureCache.Add(subAssetKey, rawTexture);
@@ -137,7 +137,7 @@ namespace UniGLTF
                     {
                         var data0 = await texDesc.Index0();
                         var rawTexture = await TextureDeserializer.LoadTextureAsync(
-                            new DeserializingTextureInfo(data0?.binary, data0?.mimeType, ColorSpace.Linear, texDesc.Sampler, texDesc.TextureType),
+                            new DeserializingTextureInfo(data0?.binary ?? default, data0?.mimeType, ColorSpace.Linear, texDesc.Sampler, texDesc.TextureType),
                             awaitCaller);
                         rawTexture.name = subAssetKey.Name;
                         _textureCache.Add(subAssetKey, rawTexture);

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureIO/Import/UnitySupportedImageTypeDeserializer.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/TextureIO/Import/UnitySupportedImageTypeDeserializer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Unity.Collections;
 using UnityEngine;
 
 namespace UniGLTF
@@ -29,12 +30,17 @@ namespace UniGLTF
 
         public async Task<Texture2D> LoadTextureAsync(DeserializingTextureInfo textureInfo, IAwaitCaller awaitCaller)
         {
-            if (textureInfo.ImageData == null) return null;
+            if (!textureInfo.ImageData.IsCreated) return null;
 
             try
             {
                 var texture = new Texture2D(2, 2, TextureFormat.ARGB32, textureInfo.UseMipmap, textureInfo.ColorSpace == ColorSpace.Linear);
-                texture.LoadImage(textureInfo.ImageData, ImportedTexturesAccessibility.ToMarkNonReadable());
+#if UNITY_6000_0_OR_NEWER
+                // Unity 6000.0.42f1 以降は LoadImage が ReadOnlySpan を受け取れるため、NativeArray からのコピーを避ける。
+                texture.LoadImage(textureInfo.ImageData.AsReadOnlySpan(), ImportedTexturesAccessibility.ToMarkNonReadable());
+#else
+                texture.LoadImage(textureInfo.ImageData.ToArray(), ImportedTexturesAccessibility.ToMarkNonReadable());
+#endif
                 await awaitCaller.NextFrame();
 
                 texture.wrapModeU = textureInfo.WrapModeU;

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/glbImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/glbImporter.cs
@@ -76,7 +76,7 @@ namespace UniGLTF
             }
 
             int pos = 0;
-            if (!bytes[..4].Span.SequenceEqual(GLB_MAGIC_BYTES.Span))
+            if (!bytes.Span.StartsWith(GLB_MAGIC_BYTES.Span))
             {
                 throw new GlbParseException("invalid magic");
             }

--- a/Assets/UniGLTF/Runtime/UniGLTF/IO/glbImporter.cs
+++ b/Assets/UniGLTF/Runtime/UniGLTF/IO/glbImporter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 
@@ -9,7 +8,11 @@ namespace UniGLTF
     public static class glbImporter
     {
         public const string GLB_MAGIC = "glTF";
-        public const float GLB_VERSION = 2.0f;
+        public const uint GLB_VERSION = 2;
+
+        public static readonly ReadOnlyMemory<byte> GLB_MAGIC_BYTES = Encoding.ASCII.GetBytes(GLB_MAGIC);
+        public static readonly ReadOnlyMemory<byte> GLB_JSON_BYTES = BitConverter.GetBytes((uint)GlbChunkType.JSON);
+        public static readonly ReadOnlyMemory<byte> GLB_BIN_BYTES = BitConverter.GetBytes((uint)GlbChunkType.BIN);
 
         public static GlbChunkType ToChunkType(this string src)
         {
@@ -39,13 +42,30 @@ namespace UniGLTF
             }
         }
 
+        public static GlbChunkType ToChunkType(this ReadOnlyMemory<byte> src)
+        {
+            if (src.Length != 4)
+            {
+                throw new FormatException("invalid chunk type: " + src);
+            }
+            if (src.Span.SequenceEqual(GLB_JSON_BYTES.Span))
+            {
+                return GlbChunkType.JSON;
+            }
+            if (src.Span.SequenceEqual(GLB_BIN_BYTES.Span))
+            {
+                return GlbChunkType.BIN;
+            }
+            throw new FormatException("unknown chunk type: " + src);
+        }
+
         [Obsolete("Use ParseGlbChunks(bytes)")]
         public static List<GlbChunk> ParseGlbChanks(Byte[] bytes)
         {
             return ParseGlbChunks(bytes);
         }
 
-        public static List<GlbChunk> ParseGlbChunks(Byte[] bytes)
+        public static List<GlbChunk> ParseGlbChunks(ReadOnlyMemory<byte> bytes)
         {
             //
             // glb header(12byte)
@@ -56,20 +76,20 @@ namespace UniGLTF
             }
 
             int pos = 0;
-            if (Encoding.ASCII.GetString(bytes, 0, 4) != GLB_MAGIC)
+            if (!bytes[..4].Span.SequenceEqual(GLB_MAGIC_BYTES.Span))
             {
                 throw new GlbParseException("invalid magic");
             }
             pos += 4;
 
-            var version = BitConverter.ToUInt32(bytes, pos);
+            var version = BitConverter.ToUInt32(bytes[pos..].Span);
             if (version != GLB_VERSION)
             {
                 throw new GlbParseException($"unknown version: {version}");
             }
             pos += 4;
 
-            var totalLength = BitConverter.ToUInt32(bytes, pos);
+            var totalLength = BitConverter.ToUInt32(bytes[pos..].Span);
             if (bytes.Length < totalLength)
             {
                 throw new GlbParseException($"not enough size: {bytes.Length} < {totalLength}");
@@ -79,19 +99,13 @@ namespace UniGLTF
             var chunks = new List<GlbChunk>();
             while (pos < bytes.Length)
             {
-                var chunkDataSize = BitConverter.ToInt32(bytes, pos);
+                var chunkDataSize = BitConverter.ToInt32(bytes[pos..].Span);
                 pos += 4;
 
-                //var type = (GlbChunkType)BitConverter.ToUInt32(bytes, pos);
-                var chunkTypeBytes = bytes.Skip(pos).Take(4).Where(x => x != 0).ToArray();
-                var chunkTypeStr = Encoding.ASCII.GetString(chunkTypeBytes);
+                var chunkTypeBytes = bytes.Slice(pos, 4);
                 pos += 4;
 
-                chunks.Add(new GlbChunk
-                {
-                    ChunkTypeString = chunkTypeStr,
-                    Bytes = new ArraySegment<byte>(bytes, (int)pos, (int)chunkDataSize)
-                });
+                chunks.Add(new GlbChunk(chunkTypeBytes, bytes.Slice(pos, chunkDataSize)));
 
                 pos += chunkDataSize;
             }

--- a/Assets/UniGLTF/Runtime/UniJSON/ByteBuffer.cs
+++ b/Assets/UniGLTF/Runtime/UniJSON/ByteBuffer.cs
@@ -67,6 +67,13 @@ namespace UniJSON
             m_used += buffer.Count;
         }
 
+        public void Push(ReadOnlyMemory<Byte> buffer)
+        {
+            Ensure(buffer.Length);
+            buffer.Span.CopyTo(new Span<Byte>(m_buffer, m_used, buffer.Length));
+            m_used += buffer.Length;
+        }
+
         public void Unshift(int size)
         {
             if (size > m_used)

--- a/Assets/UniGLTF/Runtime/UniJSON/Extensions/ParserExtensions.cs
+++ b/Assets/UniGLTF/Runtime/UniJSON/Extensions/ParserExtensions.cs
@@ -21,5 +21,9 @@ namespace UniJSON
         {
             return JsonParser.Parse(new Utf8String(bytes));
         }
+        public static JsonNode ParseAsJson(this ReadOnlyMemory<byte> bytes)
+        {
+            return JsonParser.Parse(new Utf8String(bytes));
+        }
     }
 }

--- a/Assets/UniGLTF/Runtime/UniJSON/IStore/BytesStore.cs
+++ b/Assets/UniGLTF/Runtime/UniJSON/IStore/BytesStore.cs
@@ -93,6 +93,13 @@ namespace UniJSON
             m_pos += bytes.Count;
         }
 
+        public void Write(ReadOnlySpan<byte> bytes)
+        {
+            Require(bytes.Length);
+            bytes.CopyTo(new Span<byte>(m_buffer, m_pos, bytes.Length));
+            m_pos += bytes.Length;
+        }
+
         public void Write(sbyte value)
         {
             Require(Marshal.SizeOf(value));

--- a/Assets/UniGLTF/Runtime/UniJSON/IStore/IStore.cs
+++ b/Assets/UniGLTF/Runtime/UniJSON/IStore/IStore.cs
@@ -33,6 +33,7 @@ namespace UniJSON
         void WriteLittleEndian(Double value);
 
         void Write(ArraySegment<Byte> bytes);
+        void Write(ReadOnlySpan<Byte> bytes) => Write(new ArraySegment<Byte>(bytes.ToArray()));
 
         void Write(string src);
         void Write(char c);
@@ -53,6 +54,11 @@ namespace UniJSON
         public static void Write(this IStore s, IEnumerable<Byte> bytes)
         {
             s.Write(new ArraySegment<Byte>(bytes.ToArray()));
+        }
+
+        public static void Write(this IStore s, ReadOnlyMemory<Byte> bytes)
+        {
+            s.Write(bytes.Span);
         }
 
         public static Utf8String ToUtf8String(this IStore s)

--- a/Assets/UniGLTF/Runtime/UniJSON/IStore/StreamStore.cs
+++ b/Assets/UniGLTF/Runtime/UniJSON/IStore/StreamStore.cs
@@ -62,6 +62,11 @@ namespace UniJSON
             m_w.Write(bytes.Array, bytes.Offset, bytes.Count);
         }
 
+        public void Write(ReadOnlySpan<byte> bytes)
+        {
+            m_s.Write(bytes);
+        }
+
 #region BigEndian
         public void WriteBigEndian(int value)
         {

--- a/Assets/UniGLTF/Runtime/UniJSON/IStore/StringBuilderStore.cs
+++ b/Assets/UniGLTF/Runtime/UniJSON/IStore/StringBuilderStore.cs
@@ -40,6 +40,11 @@ namespace UniJSON
             Write(text);
         }
 
+        public void Write(ReadOnlySpan<byte> bytes)
+        {
+            Write(Encoding.UTF8.GetString(bytes));
+        }
+
         public void Write(byte value)
         {
             throw new NotImplementedException();

--- a/Assets/UniGLTF/Runtime/UniJSON/Json/JsonFormatter.cs
+++ b/Assets/UniGLTF/Runtime/UniJSON/Json/JsonFormatter.cs
@@ -266,6 +266,12 @@ namespace UniJSON
             m_w.Write(x);
         }
 
+        public void Raw(ReadOnlySpan<Byte> x)
+        {
+            CommaCheck();
+            m_w.Write(x);
+        }
+
         // ISO-8601: YYYY-MM-DD“T”hh:mm:ss“Z”
         public void Value(DateTimeOffset x)
         {

--- a/Assets/UniGLTF/Runtime/UniJSON/Json/JsonParser.cs
+++ b/Assets/UniGLTF/Runtime/UniJSON/Json/JsonParser.cs
@@ -153,7 +153,7 @@ namespace UniJSON
             }
 
             // fix array range
-            var count = current.Bytes.Offset + 1 - segment.Bytes.Offset;
+            var count = segment.ByteLength - current.ByteLength + 1;
             array.SetValueBytesCount(count);
             
             return array;
@@ -242,7 +242,7 @@ namespace UniJSON
             }
 
             // fix obj range
-            var count = current.Bytes.Offset + 1 - segment.Bytes.Offset;
+            var count = segment.ByteLength - current.ByteLength + 1;
             obj.SetValueBytesCount(count);
 
             return obj;

--- a/Assets/UniGLTF/Runtime/UniJSON/Json/JsonString.cs
+++ b/Assets/UniGLTF/Runtime/UniJSON/Json/JsonString.cs
@@ -357,7 +357,7 @@ namespace UniJSON
                                     var u = (u0 << 12) + (u1 << 8) + (u2 << 4) + u3;
                                     var utf8 = Utf8String.From(new string(new char[] { (char)u }));
                                     // var utf8 = Utf8String.From((int)u);
-                                    foreach (var x in utf8.Bytes)
+                                    foreach (var x in utf8.Bytes.Span)
                                     {
                                         Write(x);
                                     }

--- a/Assets/UniGLTF/Runtime/UniJSON/Json/JsonValue.cs
+++ b/Assets/UniGLTF/Runtime/UniJSON/Json/JsonValue.cs
@@ -6,10 +6,10 @@ namespace UniJSON
     public struct JsonValue
     {
         public Utf8String Segment;
-        public ArraySegment<Byte> Bytes { get { return Segment.Bytes; } }
+        public ReadOnlyMemory<Byte> Bytes { get { return Segment.Bytes; } }
         public void SetBytesCount(int count)
         {
-            Segment = new Utf8String(new ArraySegment<byte>(Bytes.Array, Bytes.Offset, count));
+            Segment = new Utf8String(Segment.Bytes.Slice(0, count));
         }
 
         public ValueNodeType ValueType

--- a/Assets/UniGLTF/Runtime/UniJSON/ListTreeNode/ListTreeNode.cs
+++ b/Assets/UniGLTF/Runtime/UniJSON/ListTreeNode/ListTreeNode.cs
@@ -332,6 +332,11 @@ namespace UniJSON
             return AddValue(default(JsonValue).New(bytes, valueType, ValueIndex));
         }
 
+        public JsonNode AddValue(ReadOnlyMemory<byte> bytes, ValueNodeType valueType)
+        {
+            return AddValue(new JsonValue(new Utf8String(bytes), valueType, ValueIndex));
+        }
+
         public JsonNode AddValue(JsonValue value)
         {
             if (m_Values == null)

--- a/Assets/UniGLTF/Runtime/UniJSON/Utf8String/Utf8Iterator.cs
+++ b/Assets/UniGLTF/Runtime/UniJSON/Utf8String/Utf8Iterator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -7,24 +7,20 @@ namespace UniJSON
 {
     public struct Utf8Iterator : IEnumerator<Byte>
     {
-        Byte[] m_bytes;
-        int m_offset;
+        ReadOnlyMemory<byte> m_memory;
         int m_start;
         int m_position;
-        int m_end;
 
-        public Utf8Iterator(ArraySegment<Byte> range, int start = 0)
+        public Utf8Iterator(ReadOnlyMemory<Byte> memory, int start = 0)
         {
-            m_bytes = range.Array;
-            m_offset = range.Offset;
-            m_start = m_offset + start;
+            m_memory = memory;
+            m_start = start;
             m_position = -1;
-            m_end = range.Offset + range.Count;
         }
 
         public int BytePosition
         {
-            get { return m_position - m_offset; }
+            get { return m_position; }
         }
 
         public int CurrentByteLength
@@ -57,7 +53,7 @@ namespace UniJSON
 
         public byte Current
         {
-            get { return m_bytes[m_position]; }
+            get { return m_memory.Span[m_position]; }
         }
 
         object IEnumerator.Current
@@ -67,17 +63,17 @@ namespace UniJSON
 
         public byte Second
         {
-            get { return m_bytes[m_position + 1]; }
+            get { return m_memory.Span[m_position + 1]; }
         }
 
         public byte Third
         {
-            get { return m_bytes[m_position + 2]; }
+            get { return m_memory.Span[m_position + 2]; }
         }
 
         public byte Fourth
         {
-            get { return m_bytes[m_position + 3]; }
+            get { return m_memory.Span[m_position + 3]; }
         }
 
         public const uint Mask1 = 0x01;
@@ -188,7 +184,7 @@ namespace UniJSON
             {
                 m_position += CurrentByteLength;
             }
-            return m_position < m_end;
+            return m_position < m_memory.Length;
         }
 
         public void Reset()

--- a/Assets/UniGLTF/Runtime/UniJSON/Utf8String/Utf8String.cs
+++ b/Assets/UniGLTF/Runtime/UniJSON/Utf8String/Utf8String.cs
@@ -8,10 +8,10 @@ namespace UniJSON
     {
         public static readonly System.Text.Encoding Encoding = new System.Text.UTF8Encoding(false);
 
-        public readonly ArraySegment<Byte> Bytes;
+        public readonly ReadOnlyMemory<Byte> Bytes;
         public int ByteLength
         {
-            get { return Bytes.Count; }
+            get { return Bytes.Length; }
         }
 
         public Utf8Iterator GetIterator()
@@ -49,20 +49,27 @@ namespace UniJSON
 
         public Byte this[int i]
         {
-            get { return Bytes.Array[Bytes.Offset + i]; }
+            get { return Bytes.Span[i]; }
         }
 
-        public Utf8String(ArraySegment<Byte> bytes)
+        public Utf8String(ReadOnlyMemory<Byte> bytes)
         {
             Bytes = bytes;
         }
 
-        public Utf8String(Byte[] bytes, int offset, int count) : this(new ArraySegment<Byte>(bytes, offset, count))
+        public Utf8String(ArraySegment<Byte> bytes)
         {
+            Bytes = new ReadOnlyMemory<Byte>(bytes.Array, bytes.Offset, bytes.Count);
         }
 
-        public Utf8String(Byte[] bytes) : this(bytes, 0, bytes.Length)
+        public Utf8String(Byte[] bytes, int offset, int count)
         {
+            Bytes = new ReadOnlyMemory<Byte>(bytes, offset, count);
+        }
+
+        public Utf8String(Byte[] bytes)
+        {
+            Bytes = new ReadOnlyMemory<Byte>(bytes);
         }
 
         public static Utf8String From(string src)
@@ -99,27 +106,27 @@ namespace UniJSON
                     bytes[pos++] = (byte)(Utf8Iterator.Head1 | Utf8Iterator.Mask6 & (c));
                 }
             }
-            return new Utf8String(new ArraySegment<byte>(bytes, 0, pos));
+            return new Utf8String(bytes, 0, pos);
         }
 
         public Utf8String Concat(Utf8String rhs)
         {
             var bytes = new Byte[ByteLength + rhs.ByteLength];
-            Buffer.BlockCopy(Bytes.Array, Bytes.Offset, bytes, 0, ByteLength);
-            Buffer.BlockCopy(rhs.Bytes.Array, rhs.Bytes.Offset, bytes, ByteLength, rhs.ByteLength);
+            Bytes.Span.CopyTo(bytes);
+            rhs.Bytes.Span.CopyTo(bytes.AsSpan(ByteLength));
             return new Utf8String(bytes);
         }
 
         public override string ToString()
         {
             if (ByteLength == 0) return "";
-            return Encoding.GetString(Bytes.Array, Bytes.Offset, Bytes.Count);
+            return Encoding.GetString(Bytes.Span);
         }
 
         public string ToAscii()
         {
             if (ByteLength == 0) return "";
-            return System.Text.Encoding.ASCII.GetString(Bytes.Array, Bytes.Offset, Bytes.Count);
+            return System.Text.Encoding.ASCII.GetString(Bytes.Span);
         }
 
         public bool IsEmpty
@@ -173,12 +180,12 @@ namespace UniJSON
 
         public int IndexOf(int offset, Byte code)
         {
-            var pos = offset + Bytes.Offset;
-            for (int i = 0; i < Bytes.Count; ++i, ++pos)
+            var span = Bytes.Span;
+            for (int i = offset; i < span.Length; ++i)
             {
-                if (Bytes.Array[pos] == code)
+                if (span[i] == code)
                 {
-                    return pos - Bytes.Offset;
+                    return i;
                 }
             }
             return -1;
@@ -191,7 +198,7 @@ namespace UniJSON
 
         public Utf8String Subbytes(int offset, int count)
         {
-            return new Utf8String(Bytes.Array, Bytes.Offset + offset, count);
+            return new Utf8String(Bytes.Slice(offset, count));
         }
 
         static bool IsSpace(Byte b)
@@ -281,7 +288,7 @@ namespace UniJSON
 
         public static Utf8String operator +(Utf8String l, Utf8String r)
         {
-            return new Utf8String(l.Bytes.Concat(r.Bytes));
+            return l.Concat(r);
         }
 
         public bool IsInt

--- a/Assets/UniGLTF/Runtime/UniJSON/Utf8String/Utf8String.cs
+++ b/Assets/UniGLTF/Runtime/UniJSON/Utf8String/Utf8String.cs
@@ -59,17 +59,17 @@ namespace UniJSON
 
         public Utf8String(ArraySegment<Byte> bytes)
         {
-            Bytes = new ReadOnlyMemory<Byte>(bytes.Array, bytes.Offset, bytes.Count);
+            Bytes = bytes;
         }
 
         public Utf8String(Byte[] bytes, int offset, int count)
         {
-            Bytes = new ReadOnlyMemory<Byte>(bytes, offset, count);
+            Bytes = bytes.AsMemory(offset,count);
         }
 
         public Utf8String(Byte[] bytes)
         {
-            Bytes = new ReadOnlyMemory<Byte>(bytes);
+            Bytes = bytes;
         }
 
         public static Utf8String From(string src)

--- a/Assets/UniGLTF/Runtime/UniJSON/Utf8String/Utf8StringExtensions.cs
+++ b/Assets/UniGLTF/Runtime/UniJSON/Utf8String/Utf8StringExtensions.cs
@@ -9,7 +9,7 @@ namespace UniJSON
     {
         public static void WriteTo(this Utf8String src, Stream dst)
         {
-            dst.Write(src.Bytes.Array, src.Bytes.Offset, src.Bytes.Count);
+            dst.Write(src.Bytes.Span);
         }
 
         public static Utf8Iterator GetFirst(this Utf8String src)

--- a/Assets/UniGLTF/Runtime/Utils/MathHelper.cs
+++ b/Assets/UniGLTF/Runtime/Utils/MathHelper.cs
@@ -27,7 +27,10 @@ namespace UniGLTF.Runtime.Utils
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static quaternion FromToRotation(in float3 fromVector, in float3 toVector)
         {
-            if (math.lengthsq(fromVector) == 0 || math.lengthsq(toVector) == 0)
+            const float epsilon = 1e-6f;
+            const float epsilonSq = epsilon * epsilon;
+
+            if (math.lengthsq(fromVector) < epsilonSq || math.lengthsq(toVector) < epsilonSq)
             {
                 return quaternion.identity;
             }
@@ -35,15 +38,15 @@ namespace UniGLTF.Runtime.Utils
             float3 from = math.normalizesafe(fromVector);
             float3 to = math.normalizesafe(toVector);
 
-            var dot = math.dot(from, to);
-            switch(dot)
+            var dot = math.clamp(math.dot(from, to), -1.0f, 1.0f);
+            switch (dot)
             {
-                case >= 1.0f:
-                    return quaternion.identity; 
-                case <= -1.0f:
+                case > 1.0f - epsilon:
+                    return quaternion.identity;
+                case < -1.0f + epsilon:
                 {
                     var axis = math.cross(from, new float3(1, 0, 0));
-                    if (math.lengthsq(axis) < 0.0001f)
+                    if (math.lengthsq(axis) < epsilonSq)
                     {
                         axis = math.cross(from, new float3(0, 1, 0));
                     }

--- a/Assets/UniGLTF/Runtime/Utils/MathHelper.cs
+++ b/Assets/UniGLTF/Runtime/Utils/MathHelper.cs
@@ -32,8 +32,8 @@ namespace UniGLTF.Runtime.Utils
                 return quaternion.identity;
             }
 
-            float3 from = math.normalize(fromVector);
-            float3 to = math.normalize(toVector);
+            float3 from = math.normalizesafe(fromVector);
+            float3 to = math.normalizesafe(toVector);
 
             var dot = math.dot(from, to);
             switch(dot)
@@ -47,13 +47,13 @@ namespace UniGLTF.Runtime.Utils
                     {
                         axis = math.cross(from, new float3(0, 1, 0));
                     }
-                    return quaternion.AxisAngle(math.normalize(axis), math.PI);
+                    return quaternion.AxisAngle(math.normalizesafe(axis), math.PI);
                 }
                 default:
                 {
                     var angle = math.acos(dot);
                     var axis = math.cross(from, to);
-                    return quaternion.AxisAngle(math.normalize(axis), angle);
+                    return quaternion.AxisAngle(math.normalizesafe(axis), angle);
                 }
             }
         }

--- a/Assets/UniGLTF/Tests/UniGLTF/GlbParserTests.cs
+++ b/Assets/UniGLTF/Tests/UniGLTF/GlbParserTests.cs
@@ -66,7 +66,7 @@ namespace UniGLTF
             {
 
                 // glb header + 1st chunk only
-                var mod = bytes.Take(12 + 8 + data.Chunks[0].Bytes.Count).ToArray();
+                var mod = bytes.Take(12 + 8 + data.Chunks[0].Bytes.Length).ToArray();
 
                 Assert.Throws<GlbParseException>(() =>
                 {

--- a/Assets/UniGLTF/Tests/UniGLTF/MathTests.cs
+++ b/Assets/UniGLTF/Tests/UniGLTF/MathTests.cs
@@ -45,5 +45,66 @@ namespace UniGLTF
             var expected = Quaternion.FromToRotation(_vector1, _vector2);
             Assert.That(MathHelper.Approximately(result, expected), Is.True);
         }
+
+        [Test]
+        public void FromToRotationMatchesUnityForStandardCasesTest()
+        {
+            AssertFromToRotationMatchesUnity(new float3(1, 0, 0), new float3(0, 1, 0));
+            AssertFromToRotationMatchesUnity(new float3(0, 1, 0), new float3(0, 0, 1));
+            AssertFromToRotationMatchesUnity(new float3(1, 2, 3), new float3(4, 5, 6));
+            AssertFromToRotationMatchesUnity(new float3(-2, 0.5f, 3), new float3(1, -4, 0.25f));
+        }
+
+        [Test]
+        public void FromToRotationSameDirectionTest()
+        {
+            AssertFromToRotation(new float3(1, 0, 0), new float3(2, 0, 0));
+            AssertFromToRotation(new float3(1, 2, 3), new float3(2, 4, 6));
+        }
+
+        [Test]
+        public void FromToRotationOppositeDirectionTest()
+        {
+            AssertFromToRotation(new float3(1, 0, 0), new float3(-1, 0, 0));
+            AssertFromToRotation(new float3(0, 1, 0), new float3(0, -1, 0));
+            AssertFromToRotation(new float3(0, 0, 1), new float3(0, 0, -1));
+            AssertFromToRotation(new float3(1, 2, 3), new float3(-1, -2, -3));
+        }
+
+        [Test]
+        public void FromToRotationNearlyOppositeDirectionTest()
+        {
+            AssertFromToRotation(new float3(1, 0, 0), math.normalize(new float3(-1, 0.0001f, 0)));
+            AssertFromToRotation(new float3(1, 2, 3), math.normalize(new float3(-1.0001f, -2, -3)));
+        }
+
+        [Test]
+        public void FromToRotationZeroVectorTest()
+        {
+            Assert.That(MathHelper.Approximately(MathHelper.FromToRotation(float3.zero, new float3(0, 1, 0)), quaternion.identity), Is.True);
+            Assert.That(MathHelper.Approximately(MathHelper.FromToRotation(new float3(1, 0, 0), float3.zero), quaternion.identity), Is.True);
+        }
+
+        [Test]
+        public void FromToRotationTinyVectorTest()
+        {
+            var result = MathHelper.FromToRotation(new float3(1e-12f, 0, 0), new float3(0, 1, 0));
+            Assert.That(MathHelper.Approximately(result, quaternion.identity), Is.True);
+        }
+
+        private static void AssertFromToRotation(float3 from, float3 to)
+        {
+            var result = MathHelper.FromToRotation(from, to);
+            var rotated = math.mul(result, math.normalize(from));
+            var dot = math.dot(math.normalize(rotated), math.normalize(to));
+            Assert.That(dot, Is.GreaterThan(0.9999f));
+        }
+
+        private static void AssertFromToRotationMatchesUnity(float3 from, float3 to)
+        {
+            var result = MathHelper.FromToRotation(from, to);
+            var expected = Quaternion.FromToRotation(from, to);
+            Assert.That(MathHelper.Approximately(result, expected), Is.True);
+        }
     }
 }

--- a/Assets/UniGLTF/Tests/UniGLTF/TextureEnumerateTests.cs
+++ b/Assets/UniGLTF/Tests/UniGLTF/TextureEnumerateTests.cs
@@ -232,7 +232,7 @@ namespace UniGLTF
         {
             return new GltfData(
                 string.Empty,
-                string.Empty,
+                Array.Empty<byte>(),
                 gltf,
                 new List<GlbChunk>(),
                 default,

--- a/Assets/UniGLTF/Tests/UniJSON/Json/JsonParserTest.cs
+++ b/Assets/UniGLTF/Tests/UniJSON/Json/JsonParserTest.cs
@@ -26,8 +26,7 @@ namespace UniJSON
         {
             {
                 var node = JsonParser.Parse("null");
-                Assert.AreEqual(0, node.Value.Bytes.Offset);
-                Assert.AreEqual(4, node.Value.Bytes.Count);
+                Assert.AreEqual(4, node.Value.Bytes.Length);
                 Assert.True(node.IsNull());
             }
         }
@@ -37,16 +36,14 @@ namespace UniJSON
         {
             {
                 var node = JsonParser.Parse("true");
-                Assert.AreEqual(0, node.Value.Bytes.Offset);
-                Assert.AreEqual(4, node.Value.Bytes.Count);
+                Assert.AreEqual(4, node.Value.Bytes.Length);
                 Assert.True(node.IsBoolean());
                 Assert.AreEqual(true, node.GetBoolean());
                 Assert.Catch(typeof(FormatException), () => node.GetDouble());
             }
             {
                 var node = JsonParser.Parse(" false ");
-                Assert.AreEqual(1, node.Value.Bytes.Offset);
-                Assert.AreEqual(5, node.Value.Bytes.Count);
+                Assert.AreEqual(5, node.Value.Bytes.Length);
                 Assert.True(node.IsBoolean());
                 Assert.AreEqual(false, node.GetBoolean());
             }
@@ -57,23 +54,20 @@ namespace UniJSON
         {
             {
                 var node = JsonParser.Parse("1");
-                Assert.AreEqual(0, node.Value.Bytes.Offset);
-                Assert.AreEqual(1, node.Value.Bytes.Count);
+                Assert.AreEqual(1, node.Value.Bytes.Length);
                 Assert.True(node.IsInteger());
                 Assert.AreEqual(1, (int)node.GetDouble());
                 Assert.Catch(typeof(DeserializationException), () => node.GetBoolean());
             }
             {
                 var node = JsonParser.Parse(" 22 ");
-                Assert.AreEqual(1, node.Value.Bytes.Offset);
-                Assert.AreEqual(2, node.Value.Bytes.Count);
+                Assert.AreEqual(2, node.Value.Bytes.Length);
                 Assert.True(node.IsInteger());
                 Assert.AreEqual(22, (int)node.GetDouble());
             }
             {
                 var node = JsonParser.Parse(" 3.3 ");
-                Assert.AreEqual(1, node.Value.Bytes.Offset);
-                Assert.AreEqual(3, node.Value.Bytes.Count);
+                Assert.AreEqual(3, node.Value.Bytes.Length);
                 Assert.True(node.IsFloat());
                 Assert.AreEqual(3, (int)node.GetDouble());
                 Assert.AreEqual(3.3f, (float)node.GetDouble());
@@ -115,8 +109,8 @@ namespace UniJSON
                 var quoted = "\"hoge\"";
                 Assert.AreEqual(quoted, JsonString.Quote(value));
                 var node = JsonParser.Parse(quoted);
-                Assert.AreEqual(0, node.Value.Bytes.Offset);
-                Assert.AreEqual(quoted.Length, node.Value.Bytes.Count);
+
+                Assert.AreEqual(quoted.Length, node.Value.Bytes.Length);
                 Assert.True(node.IsString());
                 Assert.AreEqual("hoge", node.GetString());
             }
@@ -126,8 +120,8 @@ namespace UniJSON
                 var quoted = "\"fuga\\n  hoge\"";
                 Assert.AreEqual(quoted, JsonString.Quote(value));
                 var node = JsonParser.Parse(quoted);
-                Assert.AreEqual(0, node.Value.Bytes.Offset);
-                Assert.AreEqual(quoted.Length, node.Value.Bytes.Count);
+
+                Assert.AreEqual(quoted.Length, node.Value.Bytes.Length);
                 Assert.True(node.IsString());
                 Assert.AreEqual(value, node.GetString());
             }
@@ -192,9 +186,9 @@ namespace UniJSON
             {
                 var json = "{}";
                 var node = JsonParser.Parse(json);
-                Assert.AreEqual(0, node.Value.Bytes.Offset);
 
-                Assert.AreEqual(2, node.Value.Bytes.Count);
+
+                Assert.AreEqual(2, node.Value.Bytes.Length);
 
                 Assert.True(node.IsMap());
                 Assert.AreEqual(0, node.ObjectItems().Count());
@@ -203,8 +197,8 @@ namespace UniJSON
             {
                 var json = "{\"key\":\"value\"}";
                 var node = JsonParser.Parse(json);
-                Assert.AreEqual(0, node.Value.Bytes.Offset);
-                Assert.AreEqual(json.Length, node.Value.Bytes.Count);
+
+                Assert.AreEqual(json.Length, node.Value.Bytes.Length);
                 Assert.True(node.IsMap());
 
                 var it = node.ObjectItems().GetEnumerator();
@@ -219,8 +213,8 @@ namespace UniJSON
             {
                 var json = "{\"key\":\"value\"}";
                 var node = JsonParser.Parse(json);
-                Assert.AreEqual(0, node.Value.Bytes.Offset);
-                Assert.AreEqual(json.Length, node.Value.Bytes.Count);
+
+                Assert.AreEqual(json.Length, node.Value.Bytes.Length);
                 Assert.True(node.IsMap());
 
                 var it = node.ObjectItems().GetEnumerator();
@@ -277,10 +271,10 @@ namespace UniJSON
             {
                 var json = "[]";
                 var node = JsonParser.Parse(json);
-                Assert.AreEqual(0, node.Value.Bytes.Offset);
 
-                //Assert.Catch(() => { var result = node.Value.Bytes.Count; }, "raise exception");
-                Assert.AreEqual(2, node.Value.Bytes.Count);
+
+                //Assert.Catch(() => { var result = node.Value.Bytes.Length; }, "raise exception");
+                Assert.AreEqual(2, node.Value.Bytes.Length);
 
                 Assert.True(node.IsArray());
 
@@ -290,9 +284,9 @@ namespace UniJSON
             {
                 var json = "[1,2,3]";
                 var node = JsonParser.Parse(json);
-                Assert.AreEqual(0, node.Value.Bytes.Offset);
 
-                //Assert.Catch(() => { var result = node.Value.Bytes.Count; }, "raise exception");
+
+                //Assert.Catch(() => { var result = node.Value.Bytes.Length; }, "raise exception");
 
                 Assert.True(node.IsArray());
                 Assert.AreEqual(1, node[0].GetDouble());
@@ -305,10 +299,10 @@ namespace UniJSON
             {
                 var json = "[\"key\",1]";
                 var node = JsonParser.Parse(json);
-                Assert.AreEqual(0, node.Value.Bytes.Offset);
 
-                //Assert.Catch(() => { var result = node.Value.Bytes.Count; }, "raise exception");
-                Assert.AreEqual(json.Length, node.Value.Bytes.Count);
+
+                //Assert.Catch(() => { var result = node.Value.Bytes.Length; }, "raise exception");
+                Assert.AreEqual(json.Length, node.Value.Bytes.Length);
 
                 Assert.True(node.IsArray());
 


### PR DESCRIPTION
- PopopoでVRMロードに利用しているGlbLowLevelParserのbyte配列入力をReadOnlyMemoryでとれるようにする
- `GlbChunk`, `JsonValue`, `Utf8String`もReadOnlyMemoryで配列を保持するようにする
- 破壊的変更を避けようとすると変更が増えかねないため、いったんPopopoが必要とする部分のみ対応